### PR TITLE
make modules and options configurable so we can add custom modules

### DIFF
--- a/addon/components/quill-editor.js
+++ b/addon/components/quill-editor.js
@@ -60,6 +60,8 @@ export default Component.extend({
 	scrollingContainer: null,
 	theme: 'snow',
 	toolbar: toolbar,
+	modules: modules,
+	options: options,
 
 	// ------------------------------
 	// Set quill editor
@@ -71,9 +73,9 @@ export default Component.extend({
 
 		// Get the defined quill options.
 
-		let settings = this.getProperties(options);
+		let settings = this.getProperties(this.options);
 
-		settings.modules = this.getProperties(modules);
+		settings.modules = this.getProperties(this.modules);
 
 		// Instantiate the Quill editor instance.
 


### PR DESCRIPTION
Use `modules` and `options` in component so we can add custom modules.

Example if i want to add `imageResize` as module i am not able to add it to `modules` since its a global outside of the component.